### PR TITLE
feature/jenkins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ ENV ANDROID_HOME /usr/local/android-sdk-linux
 ENV PATH $PATH:$ANDROID_HOME/tools:$ANDROID_HOME/platform-tools
 
 # update and accept licences
-RUN ( sleep 5 && while [ 1 ]; do sleep 1; echo y; done ) | /usr/local/android-sdk-linux/tools/android update sdk --no-ui -a --filter platform-tool,build-tools-22.0.1,android-22
+RUN ( sleep 5 && while [ 1 ]; do sleep 1; echo y; done ) | /usr/local/android-sdk-linux/tools/android update sdk --no-ui -a --filter platform-tool,build-tools-22.0.1,android-22; \
+    find /usr/local/android-sdk-linux -perm 0744 | xargs chmod 755
 
 ENV GRADLE_USER_HOME /src/gradle
 VOLUME /src

--- a/readme.md
+++ b/readme.md
@@ -42,9 +42,19 @@ That's it, your app should be on your phone!
 
 ## Useful commands
 
-List of attached devices. make sure you see your phone in that list.
+### List of attached devices
 
-    docker run --rm -i -v $(pwd):/workspace -w /workspace --privileged -v /dev/bus/usb:/dev/bus/usb cordova adb devices
+Make sure you see your phone in that list.
+
+    docker run --rm -i -v $(pwd):/workspace -w /workspace \
+        --privileged -v /dev/bus/usb:/dev/bus/usb cordova adb devices
+
+### Run with different user
+
+To ensure the container uses the same user id as the caller use the
+-u option and provide a writeable HOME directory to that user (change the alias if necessary!)
+
+    alias cordova='docker run --rm -i -u `id -u` -v $PWD:/src -e "HOME=/tmp" cordova cordova'
 
 ## References
 


### PR DESCRIPTION
I tried running the image as Jenkins user and ran into the following problem: The created files belonged to the root user and it was not possible to clean them up later with non-privileged user.

Therefor I created the following patch:
- Allow execution of all commands in /usr/local/android-sdk-linux for all users
- Run under the same user id of the current caller (this is up to the caller by providing a suitable flag, see readme.md)
